### PR TITLE
fix: recreate resources if deleted

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - name: Tests
         run: make test
       - name: Send go coverage report

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - name: fmt
         run: make fmt
       - name: vet
@@ -90,7 +90,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - name: run test
         run: make test ENVTEST_K8S_VERSION=${{ matrix.kubernetes-version }}
 
@@ -108,7 +108,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - name: build
         run: make build
       - name: Check if working tree is dirty
@@ -153,7 +153,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - name: Setup Kubernetes
         uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0 #v0.5.0
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: '1.22'
+          go-version: 1.23.x
       - name: Docker Login
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ vet: ## Run go vet against code.
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint against code
-	$(GOLANGCI_LINT) run --timeout=2m ./...
+	$(GOLANGCI_LINT) run --timeout=3m ./...
 
 .PHONY: test
 test: envtest manifests generate fmt vet tidy ## Run tests.
@@ -139,7 +139,7 @@ controller-gen: ## Download controller-gen locally if necessary.
 GOLANGCI_LINT = $(GOBIN)/golangci-lint
 .PHONY: golangci-lint
 golangci-lint: ## Download golint locally if necessary
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.0)
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.4)
 
 KUSTOMIZE = $(GOBIN)/kustomize
 .PHONY: kustomize

--- a/chart/ratelimit-controller/crds/ratelimit.infra.doodle.com_ratelimitservices.yaml
+++ b/chart/ratelimit-controller/crds/ratelimit.infra.doodle.com_ratelimitservices.yaml
@@ -1388,8 +1388,8 @@ spec:
                                             More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
-                                              description: Exec specifies the action
-                                                to take.
+                                              description: Exec specifies a command
+                                                to execute in the container.
                                               properties:
                                                 command:
                                                   description: |-
@@ -1404,8 +1404,8 @@ spec:
                                                   x-kubernetes-list-type: atomic
                                               type: object
                                             httpGet:
-                                              description: HTTPGet specifies the http
-                                                request to perform.
+                                              description: HTTPGet specifies an HTTP
+                                                GET request to perform.
                                               properties:
                                                 host:
                                                   description: |-
@@ -1458,9 +1458,8 @@ spec:
                                               - port
                                               type: object
                                             sleep:
-                                              description: Sleep represents the duration
-                                                that the container should sleep before
-                                                being terminated.
+                                              description: Sleep represents a duration
+                                                that the container should sleep.
                                               properties:
                                                 seconds:
                                                   description: Seconds is the number
@@ -1473,8 +1472,8 @@ spec:
                                             tcpSocket:
                                               description: |-
                                                 Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                                for the backward compatibility. There are no validation of this field and
-                                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                                                for backward compatibility. There is no validation of this field and
+                                                lifecycle hooks will fail at runtime when it is specified.
                                               properties:
                                                 host:
                                                   description: 'Optional: Host name
@@ -1507,8 +1506,8 @@ spec:
                                             More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
-                                              description: Exec specifies the action
-                                                to take.
+                                              description: Exec specifies a command
+                                                to execute in the container.
                                               properties:
                                                 command:
                                                   description: |-
@@ -1523,8 +1522,8 @@ spec:
                                                   x-kubernetes-list-type: atomic
                                               type: object
                                             httpGet:
-                                              description: HTTPGet specifies the http
-                                                request to perform.
+                                              description: HTTPGet specifies an HTTP
+                                                GET request to perform.
                                               properties:
                                                 host:
                                                   description: |-
@@ -1577,9 +1576,8 @@ spec:
                                               - port
                                               type: object
                                             sleep:
-                                              description: Sleep represents the duration
-                                                that the container should sleep before
-                                                being terminated.
+                                              description: Sleep represents a duration
+                                                that the container should sleep.
                                               properties:
                                                 seconds:
                                                   description: Seconds is the number
@@ -1592,8 +1590,8 @@ spec:
                                             tcpSocket:
                                               description: |-
                                                 Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                                for the backward compatibility. There are no validation of this field and
-                                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                                                for backward compatibility. There is no validation of this field and
+                                                lifecycle hooks will fail at runtime when it is specified.
                                               properties:
                                                 host:
                                                   description: 'Optional: Host name
@@ -1622,8 +1620,8 @@ spec:
                                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
+                                          description: Exec specifies a command to
+                                            execute in the container.
                                           properties:
                                             command:
                                               description: |-
@@ -1644,8 +1642,7 @@ spec:
                                           format: int32
                                           type: integer
                                         grpc:
-                                          description: GRPC specifies an action involving
-                                            a GRPC port.
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
                                           properties:
                                             port:
                                               description: Port number of the gRPC
@@ -1665,7 +1662,7 @@ spec:
                                           - port
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
+                                          description: HTTPGet specifies an HTTP GET
                                             request to perform.
                                           properties:
                                             host:
@@ -1737,8 +1734,8 @@ spec:
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: TCPSocket specifies an action
-                                            involving a TCP port.
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -1843,8 +1840,8 @@ spec:
                                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
+                                          description: Exec specifies a command to
+                                            execute in the container.
                                           properties:
                                             command:
                                               description: |-
@@ -1865,8 +1862,7 @@ spec:
                                           format: int32
                                           type: integer
                                         grpc:
-                                          description: GRPC specifies an action involving
-                                            a GRPC port.
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
                                           properties:
                                             port:
                                               description: Port number of the gRPC
@@ -1886,7 +1882,7 @@ spec:
                                           - port
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
+                                          description: HTTPGet specifies an HTTP GET
                                             request to perform.
                                           properties:
                                             host:
@@ -1958,8 +1954,8 @@ spec:
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: TCPSocket specifies an action
-                                            involving a TCP port.
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -2310,8 +2306,8 @@ spec:
                                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
+                                          description: Exec specifies a command to
+                                            execute in the container.
                                           properties:
                                             command:
                                               description: |-
@@ -2332,8 +2328,7 @@ spec:
                                           format: int32
                                           type: integer
                                         grpc:
-                                          description: GRPC specifies an action involving
-                                            a GRPC port.
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
                                           properties:
                                             port:
                                               description: Port number of the gRPC
@@ -2353,7 +2348,7 @@ spec:
                                           - port
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
+                                          description: HTTPGet specifies an HTTP GET
                                             request to perform.
                                           properties:
                                             host:
@@ -2425,8 +2420,8 @@ spec:
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: TCPSocket specifies an action
-                                            involving a TCP port.
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -2641,9 +2636,13 @@ spec:
                                         resolver options of a pod.
                                       properties:
                                         name:
-                                          description: Required.
+                                          description: |-
+                                            Name is this DNS resolver option's name.
+                                            Required.
                                           type: string
                                         value:
+                                          description: Value is this DNS resolver
+                                            option's value.
                                           type: string
                                       type: object
                                     type: array
@@ -2932,8 +2931,8 @@ spec:
                                             More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
-                                              description: Exec specifies the action
-                                                to take.
+                                              description: Exec specifies a command
+                                                to execute in the container.
                                               properties:
                                                 command:
                                                   description: |-
@@ -2948,8 +2947,8 @@ spec:
                                                   x-kubernetes-list-type: atomic
                                               type: object
                                             httpGet:
-                                              description: HTTPGet specifies the http
-                                                request to perform.
+                                              description: HTTPGet specifies an HTTP
+                                                GET request to perform.
                                               properties:
                                                 host:
                                                   description: |-
@@ -3002,9 +3001,8 @@ spec:
                                               - port
                                               type: object
                                             sleep:
-                                              description: Sleep represents the duration
-                                                that the container should sleep before
-                                                being terminated.
+                                              description: Sleep represents a duration
+                                                that the container should sleep.
                                               properties:
                                                 seconds:
                                                   description: Seconds is the number
@@ -3017,8 +3015,8 @@ spec:
                                             tcpSocket:
                                               description: |-
                                                 Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                                for the backward compatibility. There are no validation of this field and
-                                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                                                for backward compatibility. There is no validation of this field and
+                                                lifecycle hooks will fail at runtime when it is specified.
                                               properties:
                                                 host:
                                                   description: 'Optional: Host name
@@ -3051,8 +3049,8 @@ spec:
                                             More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
-                                              description: Exec specifies the action
-                                                to take.
+                                              description: Exec specifies a command
+                                                to execute in the container.
                                               properties:
                                                 command:
                                                   description: |-
@@ -3067,8 +3065,8 @@ spec:
                                                   x-kubernetes-list-type: atomic
                                               type: object
                                             httpGet:
-                                              description: HTTPGet specifies the http
-                                                request to perform.
+                                              description: HTTPGet specifies an HTTP
+                                                GET request to perform.
                                               properties:
                                                 host:
                                                   description: |-
@@ -3121,9 +3119,8 @@ spec:
                                               - port
                                               type: object
                                             sleep:
-                                              description: Sleep represents the duration
-                                                that the container should sleep before
-                                                being terminated.
+                                              description: Sleep represents a duration
+                                                that the container should sleep.
                                               properties:
                                                 seconds:
                                                   description: Seconds is the number
@@ -3136,8 +3133,8 @@ spec:
                                             tcpSocket:
                                               description: |-
                                                 Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                                for the backward compatibility. There are no validation of this field and
-                                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                                                for backward compatibility. There is no validation of this field and
+                                                lifecycle hooks will fail at runtime when it is specified.
                                               properties:
                                                 host:
                                                   description: 'Optional: Host name
@@ -3163,8 +3160,8 @@ spec:
                                         containers.
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
+                                          description: Exec specifies a command to
+                                            execute in the container.
                                           properties:
                                             command:
                                               description: |-
@@ -3185,8 +3182,7 @@ spec:
                                           format: int32
                                           type: integer
                                         grpc:
-                                          description: GRPC specifies an action involving
-                                            a GRPC port.
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
                                           properties:
                                             port:
                                               description: Port number of the gRPC
@@ -3206,7 +3202,7 @@ spec:
                                           - port
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
+                                          description: HTTPGet specifies an HTTP GET
                                             request to perform.
                                           properties:
                                             host:
@@ -3278,8 +3274,8 @@ spec:
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: TCPSocket specifies an action
-                                            involving a TCP port.
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -3374,8 +3370,8 @@ spec:
                                         containers.
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
+                                          description: Exec specifies a command to
+                                            execute in the container.
                                           properties:
                                             command:
                                               description: |-
@@ -3396,8 +3392,7 @@ spec:
                                           format: int32
                                           type: integer
                                         grpc:
-                                          description: GRPC specifies an action involving
-                                            a GRPC port.
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
                                           properties:
                                             port:
                                               description: Port number of the gRPC
@@ -3417,7 +3412,7 @@ spec:
                                           - port
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
+                                          description: HTTPGet specifies an HTTP GET
                                             request to perform.
                                           properties:
                                             host:
@@ -3489,8 +3484,8 @@ spec:
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: TCPSocket specifies an action
-                                            involving a TCP port.
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -3822,8 +3817,8 @@ spec:
                                         containers.
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
+                                          description: Exec specifies a command to
+                                            execute in the container.
                                           properties:
                                             command:
                                               description: |-
@@ -3844,8 +3839,7 @@ spec:
                                           format: int32
                                           type: integer
                                         grpc:
-                                          description: GRPC specifies an action involving
-                                            a GRPC port.
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
                                           properties:
                                             port:
                                               description: Port number of the gRPC
@@ -3865,7 +3859,7 @@ spec:
                                           - port
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
+                                          description: HTTPGet specifies an HTTP GET
                                             request to perform.
                                           properties:
                                             host:
@@ -3937,8 +3931,8 @@ spec:
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: TCPSocket specifies an action
-                                            involving a TCP port.
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -4483,8 +4477,8 @@ spec:
                                             More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
-                                              description: Exec specifies the action
-                                                to take.
+                                              description: Exec specifies a command
+                                                to execute in the container.
                                               properties:
                                                 command:
                                                   description: |-
@@ -4499,8 +4493,8 @@ spec:
                                                   x-kubernetes-list-type: atomic
                                               type: object
                                             httpGet:
-                                              description: HTTPGet specifies the http
-                                                request to perform.
+                                              description: HTTPGet specifies an HTTP
+                                                GET request to perform.
                                               properties:
                                                 host:
                                                   description: |-
@@ -4553,9 +4547,8 @@ spec:
                                               - port
                                               type: object
                                             sleep:
-                                              description: Sleep represents the duration
-                                                that the container should sleep before
-                                                being terminated.
+                                              description: Sleep represents a duration
+                                                that the container should sleep.
                                               properties:
                                                 seconds:
                                                   description: Seconds is the number
@@ -4568,8 +4561,8 @@ spec:
                                             tcpSocket:
                                               description: |-
                                                 Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                                for the backward compatibility. There are no validation of this field and
-                                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                                                for backward compatibility. There is no validation of this field and
+                                                lifecycle hooks will fail at runtime when it is specified.
                                               properties:
                                                 host:
                                                   description: 'Optional: Host name
@@ -4602,8 +4595,8 @@ spec:
                                             More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
-                                              description: Exec specifies the action
-                                                to take.
+                                              description: Exec specifies a command
+                                                to execute in the container.
                                               properties:
                                                 command:
                                                   description: |-
@@ -4618,8 +4611,8 @@ spec:
                                                   x-kubernetes-list-type: atomic
                                               type: object
                                             httpGet:
-                                              description: HTTPGet specifies the http
-                                                request to perform.
+                                              description: HTTPGet specifies an HTTP
+                                                GET request to perform.
                                               properties:
                                                 host:
                                                   description: |-
@@ -4672,9 +4665,8 @@ spec:
                                               - port
                                               type: object
                                             sleep:
-                                              description: Sleep represents the duration
-                                                that the container should sleep before
-                                                being terminated.
+                                              description: Sleep represents a duration
+                                                that the container should sleep.
                                               properties:
                                                 seconds:
                                                   description: Seconds is the number
@@ -4687,8 +4679,8 @@ spec:
                                             tcpSocket:
                                               description: |-
                                                 Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                                for the backward compatibility. There are no validation of this field and
-                                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                                                for backward compatibility. There is no validation of this field and
+                                                lifecycle hooks will fail at runtime when it is specified.
                                               properties:
                                                 host:
                                                   description: 'Optional: Host name
@@ -4717,8 +4709,8 @@ spec:
                                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
+                                          description: Exec specifies a command to
+                                            execute in the container.
                                           properties:
                                             command:
                                               description: |-
@@ -4739,8 +4731,7 @@ spec:
                                           format: int32
                                           type: integer
                                         grpc:
-                                          description: GRPC specifies an action involving
-                                            a GRPC port.
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
                                           properties:
                                             port:
                                               description: Port number of the gRPC
@@ -4760,7 +4751,7 @@ spec:
                                           - port
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
+                                          description: HTTPGet specifies an HTTP GET
                                             request to perform.
                                           properties:
                                             host:
@@ -4832,8 +4823,8 @@ spec:
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: TCPSocket specifies an action
-                                            involving a TCP port.
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -4938,8 +4929,8 @@ spec:
                                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
+                                          description: Exec specifies a command to
+                                            execute in the container.
                                           properties:
                                             command:
                                               description: |-
@@ -4960,8 +4951,7 @@ spec:
                                           format: int32
                                           type: integer
                                         grpc:
-                                          description: GRPC specifies an action involving
-                                            a GRPC port.
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
                                           properties:
                                             port:
                                               description: Port number of the gRPC
@@ -4981,7 +4971,7 @@ spec:
                                           - port
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
+                                          description: HTTPGet specifies an HTTP GET
                                             request to perform.
                                           properties:
                                             host:
@@ -5053,8 +5043,8 @@ spec:
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: TCPSocket specifies an action
-                                            involving a TCP port.
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -5405,8 +5395,8 @@ spec:
                                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
+                                          description: Exec specifies a command to
+                                            execute in the container.
                                           properties:
                                             command:
                                               description: |-
@@ -5427,8 +5417,7 @@ spec:
                                           format: int32
                                           type: integer
                                         grpc:
-                                          description: GRPC specifies an action involving
-                                            a GRPC port.
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
                                           properties:
                                             port:
                                               description: Port number of the gRPC
@@ -5448,7 +5437,7 @@ spec:
                                           - port
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
+                                          description: HTTPGet specifies an HTTP GET
                                             request to perform.
                                           properties:
                                             host:
@@ -5520,8 +5509,8 @@ spec:
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: TCPSocket specifies an action
-                                            involving a TCP port.
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -5889,6 +5878,75 @@ spec:
                                 x-kubernetes-list-map-keys:
                                 - name
                                 x-kubernetes-list-type: map
+                              resources:
+                                description: |-
+                                  Resources is the total amount of CPU and Memory resources required by all
+                                  containers in the pod. It supports specifying Requests and Limits for
+                                  "cpu" and "memory" resource names only. ResourceClaims are not supported.
+
+                                  This field enables fine-grained control over resource allocation for the
+                                  entire pod, allowing resource sharing among containers in a pod.
+
+                                  This is an alpha field and requires enabling the PodLevelResources feature
+                                  gate.
+                                properties:
+                                  claims:
+                                    description: |-
+                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                      that are used by this container.
+
+                                      This is an alpha field and requires enabling the
+                                      DynamicResourceAllocation feature gate.
+
+                                      This field is immutable. It can only be set for containers.
+                                    items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: |-
+                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes that resource available
+                                            inside a container.
+                                          type: string
+                                        request:
+                                          description: |-
+                                            Request is the name chosen for a request in the referenced claim.
+                                            If empty, everything from the claim is made available, otherwise
+                                            only the result of this request.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Limits describes the maximum amount of compute resources allowed.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Requests describes the minimum amount of compute resources required.
+                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                type: object
                               restartPolicy:
                                 description: |-
                                   Restart policy for all containers within the pod.
@@ -6013,6 +6071,32 @@ spec:
                                       Note that this field cannot be set when spec.os.name is windows.
                                     format: int64
                                     type: integer
+                                  seLinuxChangePolicy:
+                                    description: |-
+                                      seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                                      It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                                      Valid values are "MountOption" and "Recursive".
+
+                                      "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                                      This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                                      "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                                      This requires all Pods that share the same volume to use the same SELinux label.
+                                      It is not possible to share the same volume among privileged and unprivileged Pods.
+                                      Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                                      whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                                      CSIDriver instance. Other volumes are always re-labelled recursively.
+                                      "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                                      If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                                      If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                                      and "Recursive" for all other volumes.
+
+                                      This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                                      All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: string
                                   seLinuxOptions:
                                     description: |-
                                       The SELinux context to be applied to all containers.
@@ -6421,6 +6505,8 @@ spec:
                                       description: |-
                                         awsElasticBlockStore represents an AWS Disk resource that is attached to a
                                         kubelet's host machine and then exposed to the pod.
+                                        Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                                        awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
                                         More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                       properties:
                                         fsType:
@@ -6452,9 +6538,10 @@ spec:
                                       - volumeID
                                       type: object
                                     azureDisk:
-                                      description: azureDisk represents an Azure Data
-                                        Disk mount on the host and bind mount to the
-                                        pod.
+                                      description: |-
+                                        azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                                        Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                                        are redirected to the disk.csi.azure.com CSI driver.
                                       properties:
                                         cachingMode:
                                           description: 'cachingMode is the Host Caching
@@ -6493,9 +6580,10 @@ spec:
                                       - diskURI
                                       type: object
                                     azureFile:
-                                      description: azureFile represents an Azure File
-                                        Service mount on the host and bind mount to
-                                        the pod.
+                                      description: |-
+                                        azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                                        Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                                        are redirected to the file.csi.azure.com CSI driver.
                                       properties:
                                         readOnly:
                                           description: |-
@@ -6516,8 +6604,9 @@ spec:
                                       - shareName
                                       type: object
                                     cephfs:
-                                      description: cephFS represents a Ceph FS mount
-                                        on the host that shares a pod's lifetime
+                                      description: |-
+                                        cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                                        Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
                                       properties:
                                         monitors:
                                           description: |-
@@ -6570,6 +6659,8 @@ spec:
                                     cinder:
                                       description: |-
                                         cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                        Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                                        are redirected to the cinder.csi.openstack.org CSI driver.
                                         More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                       properties:
                                         fsType:
@@ -6681,7 +6772,7 @@ spec:
                                     csi:
                                       description: csi (Container Storage Interface)
                                         represents ephemeral storage that is handled
-                                        by certain external CSI drivers (Beta feature).
+                                        by certain external CSI drivers.
                                       properties:
                                         driver:
                                           description: |-
@@ -7163,6 +7254,7 @@ spec:
                                       description: |-
                                         flexVolume represents a generic volume resource that is
                                         provisioned/attached using an exec based plugin.
+                                        Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
                                       properties:
                                         driver:
                                           description: driver is the name of the driver
@@ -7208,10 +7300,9 @@ spec:
                                       - driver
                                       type: object
                                     flocker:
-                                      description: flocker represents a Flocker volume
-                                        attached to a kubelet's host machine. This
-                                        depends on the Flocker control service being
-                                        running
+                                      description: |-
+                                        flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                                        Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
                                       properties:
                                         datasetName:
                                           description: |-
@@ -7228,6 +7319,8 @@ spec:
                                       description: |-
                                         gcePersistentDisk represents a GCE Disk resource that is attached to a
                                         kubelet's host machine and then exposed to the pod.
+                                        Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                                        gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
                                         More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                       properties:
                                         fsType:
@@ -7263,7 +7356,7 @@ spec:
                                     gitRepo:
                                       description: |-
                                         gitRepo represents a git repository at a particular revision.
-                                        DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                        Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
                                         EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
                                         into the Pod's container.
                                       properties:
@@ -7287,6 +7380,7 @@ spec:
                                     glusterfs:
                                       description: |-
                                         glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                        Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
                                         More info: https://examples.k8s.io/volumes/glusterfs/README.md
                                       properties:
                                         endpoints:
@@ -7498,9 +7592,9 @@ spec:
                                       - claimName
                                       type: object
                                     photonPersistentDisk:
-                                      description: photonPersistentDisk represents
-                                        a PhotonController persistent disk attached
-                                        and mounted on kubelets host machine
+                                      description: |-
+                                        photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                                        Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
                                       properties:
                                         fsType:
                                           description: |-
@@ -7516,9 +7610,11 @@ spec:
                                       - pdID
                                       type: object
                                     portworxVolume:
-                                      description: portworxVolume represents a portworx
-                                        volume attached and mounted on kubelets host
-                                        machine
+                                      description: |-
+                                        portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                                        Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                                        is on.
                                       properties:
                                         fsType:
                                           description: |-
@@ -7908,8 +8004,9 @@ spec:
                                           x-kubernetes-list-type: atomic
                                       type: object
                                     quobyte:
-                                      description: quobyte represents a Quobyte mount
-                                        on the host that shares a pod's lifetime
+                                      description: |-
+                                        quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                                        Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
                                       properties:
                                         group:
                                           description: |-
@@ -7948,6 +8045,7 @@ spec:
                                     rbd:
                                       description: |-
                                         rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                        Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
                                         More info: https://examples.k8s.io/volumes/rbd/README.md
                                       properties:
                                         fsType:
@@ -8020,9 +8118,9 @@ spec:
                                       - monitors
                                       type: object
                                     scaleIO:
-                                      description: scaleIO represents a ScaleIO persistent
-                                        volume attached and mounted on Kubernetes
-                                        nodes.
+                                      description: |-
+                                        scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                                        Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
                                       properties:
                                         fsType:
                                           default: xfs
@@ -8158,9 +8256,9 @@ spec:
                                           type: string
                                       type: object
                                     storageos:
-                                      description: storageOS represents a StorageOS
-                                        volume attached and mounted on Kubernetes
-                                        nodes.
+                                      description: |-
+                                        storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                                        Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
                                       properties:
                                         fsType:
                                           description: |-
@@ -8205,9 +8303,10 @@ spec:
                                           type: string
                                       type: object
                                     vsphereVolume:
-                                      description: vsphereVolume represents a vSphere
-                                        volume attached and mounted on kubelets host
-                                        machine
+                                      description: |-
+                                        vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                                        Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                                        are redirected to the csi.vsphere.vmware.com CSI driver.
                                       properties:
                                         fsType:
                                           description: |-

--- a/config/base/crd/bases/ratelimit.infra.doodle.com_ratelimitservices.yaml
+++ b/config/base/crd/bases/ratelimit.infra.doodle.com_ratelimitservices.yaml
@@ -1388,8 +1388,8 @@ spec:
                                             More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
-                                              description: Exec specifies the action
-                                                to take.
+                                              description: Exec specifies a command
+                                                to execute in the container.
                                               properties:
                                                 command:
                                                   description: |-
@@ -1404,8 +1404,8 @@ spec:
                                                   x-kubernetes-list-type: atomic
                                               type: object
                                             httpGet:
-                                              description: HTTPGet specifies the http
-                                                request to perform.
+                                              description: HTTPGet specifies an HTTP
+                                                GET request to perform.
                                               properties:
                                                 host:
                                                   description: |-
@@ -1458,9 +1458,8 @@ spec:
                                               - port
                                               type: object
                                             sleep:
-                                              description: Sleep represents the duration
-                                                that the container should sleep before
-                                                being terminated.
+                                              description: Sleep represents a duration
+                                                that the container should sleep.
                                               properties:
                                                 seconds:
                                                   description: Seconds is the number
@@ -1473,8 +1472,8 @@ spec:
                                             tcpSocket:
                                               description: |-
                                                 Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                                for the backward compatibility. There are no validation of this field and
-                                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                                                for backward compatibility. There is no validation of this field and
+                                                lifecycle hooks will fail at runtime when it is specified.
                                               properties:
                                                 host:
                                                   description: 'Optional: Host name
@@ -1507,8 +1506,8 @@ spec:
                                             More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
-                                              description: Exec specifies the action
-                                                to take.
+                                              description: Exec specifies a command
+                                                to execute in the container.
                                               properties:
                                                 command:
                                                   description: |-
@@ -1523,8 +1522,8 @@ spec:
                                                   x-kubernetes-list-type: atomic
                                               type: object
                                             httpGet:
-                                              description: HTTPGet specifies the http
-                                                request to perform.
+                                              description: HTTPGet specifies an HTTP
+                                                GET request to perform.
                                               properties:
                                                 host:
                                                   description: |-
@@ -1577,9 +1576,8 @@ spec:
                                               - port
                                               type: object
                                             sleep:
-                                              description: Sleep represents the duration
-                                                that the container should sleep before
-                                                being terminated.
+                                              description: Sleep represents a duration
+                                                that the container should sleep.
                                               properties:
                                                 seconds:
                                                   description: Seconds is the number
@@ -1592,8 +1590,8 @@ spec:
                                             tcpSocket:
                                               description: |-
                                                 Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                                for the backward compatibility. There are no validation of this field and
-                                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                                                for backward compatibility. There is no validation of this field and
+                                                lifecycle hooks will fail at runtime when it is specified.
                                               properties:
                                                 host:
                                                   description: 'Optional: Host name
@@ -1622,8 +1620,8 @@ spec:
                                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
+                                          description: Exec specifies a command to
+                                            execute in the container.
                                           properties:
                                             command:
                                               description: |-
@@ -1644,8 +1642,7 @@ spec:
                                           format: int32
                                           type: integer
                                         grpc:
-                                          description: GRPC specifies an action involving
-                                            a GRPC port.
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
                                           properties:
                                             port:
                                               description: Port number of the gRPC
@@ -1665,7 +1662,7 @@ spec:
                                           - port
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
+                                          description: HTTPGet specifies an HTTP GET
                                             request to perform.
                                           properties:
                                             host:
@@ -1737,8 +1734,8 @@ spec:
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: TCPSocket specifies an action
-                                            involving a TCP port.
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -1843,8 +1840,8 @@ spec:
                                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
+                                          description: Exec specifies a command to
+                                            execute in the container.
                                           properties:
                                             command:
                                               description: |-
@@ -1865,8 +1862,7 @@ spec:
                                           format: int32
                                           type: integer
                                         grpc:
-                                          description: GRPC specifies an action involving
-                                            a GRPC port.
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
                                           properties:
                                             port:
                                               description: Port number of the gRPC
@@ -1886,7 +1882,7 @@ spec:
                                           - port
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
+                                          description: HTTPGet specifies an HTTP GET
                                             request to perform.
                                           properties:
                                             host:
@@ -1958,8 +1954,8 @@ spec:
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: TCPSocket specifies an action
-                                            involving a TCP port.
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -2310,8 +2306,8 @@ spec:
                                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
+                                          description: Exec specifies a command to
+                                            execute in the container.
                                           properties:
                                             command:
                                               description: |-
@@ -2332,8 +2328,7 @@ spec:
                                           format: int32
                                           type: integer
                                         grpc:
-                                          description: GRPC specifies an action involving
-                                            a GRPC port.
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
                                           properties:
                                             port:
                                               description: Port number of the gRPC
@@ -2353,7 +2348,7 @@ spec:
                                           - port
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
+                                          description: HTTPGet specifies an HTTP GET
                                             request to perform.
                                           properties:
                                             host:
@@ -2425,8 +2420,8 @@ spec:
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: TCPSocket specifies an action
-                                            involving a TCP port.
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -2641,9 +2636,13 @@ spec:
                                         resolver options of a pod.
                                       properties:
                                         name:
-                                          description: Required.
+                                          description: |-
+                                            Name is this DNS resolver option's name.
+                                            Required.
                                           type: string
                                         value:
+                                          description: Value is this DNS resolver
+                                            option's value.
                                           type: string
                                       type: object
                                     type: array
@@ -2932,8 +2931,8 @@ spec:
                                             More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
-                                              description: Exec specifies the action
-                                                to take.
+                                              description: Exec specifies a command
+                                                to execute in the container.
                                               properties:
                                                 command:
                                                   description: |-
@@ -2948,8 +2947,8 @@ spec:
                                                   x-kubernetes-list-type: atomic
                                               type: object
                                             httpGet:
-                                              description: HTTPGet specifies the http
-                                                request to perform.
+                                              description: HTTPGet specifies an HTTP
+                                                GET request to perform.
                                               properties:
                                                 host:
                                                   description: |-
@@ -3002,9 +3001,8 @@ spec:
                                               - port
                                               type: object
                                             sleep:
-                                              description: Sleep represents the duration
-                                                that the container should sleep before
-                                                being terminated.
+                                              description: Sleep represents a duration
+                                                that the container should sleep.
                                               properties:
                                                 seconds:
                                                   description: Seconds is the number
@@ -3017,8 +3015,8 @@ spec:
                                             tcpSocket:
                                               description: |-
                                                 Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                                for the backward compatibility. There are no validation of this field and
-                                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                                                for backward compatibility. There is no validation of this field and
+                                                lifecycle hooks will fail at runtime when it is specified.
                                               properties:
                                                 host:
                                                   description: 'Optional: Host name
@@ -3051,8 +3049,8 @@ spec:
                                             More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
-                                              description: Exec specifies the action
-                                                to take.
+                                              description: Exec specifies a command
+                                                to execute in the container.
                                               properties:
                                                 command:
                                                   description: |-
@@ -3067,8 +3065,8 @@ spec:
                                                   x-kubernetes-list-type: atomic
                                               type: object
                                             httpGet:
-                                              description: HTTPGet specifies the http
-                                                request to perform.
+                                              description: HTTPGet specifies an HTTP
+                                                GET request to perform.
                                               properties:
                                                 host:
                                                   description: |-
@@ -3121,9 +3119,8 @@ spec:
                                               - port
                                               type: object
                                             sleep:
-                                              description: Sleep represents the duration
-                                                that the container should sleep before
-                                                being terminated.
+                                              description: Sleep represents a duration
+                                                that the container should sleep.
                                               properties:
                                                 seconds:
                                                   description: Seconds is the number
@@ -3136,8 +3133,8 @@ spec:
                                             tcpSocket:
                                               description: |-
                                                 Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                                for the backward compatibility. There are no validation of this field and
-                                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                                                for backward compatibility. There is no validation of this field and
+                                                lifecycle hooks will fail at runtime when it is specified.
                                               properties:
                                                 host:
                                                   description: 'Optional: Host name
@@ -3163,8 +3160,8 @@ spec:
                                         containers.
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
+                                          description: Exec specifies a command to
+                                            execute in the container.
                                           properties:
                                             command:
                                               description: |-
@@ -3185,8 +3182,7 @@ spec:
                                           format: int32
                                           type: integer
                                         grpc:
-                                          description: GRPC specifies an action involving
-                                            a GRPC port.
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
                                           properties:
                                             port:
                                               description: Port number of the gRPC
@@ -3206,7 +3202,7 @@ spec:
                                           - port
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
+                                          description: HTTPGet specifies an HTTP GET
                                             request to perform.
                                           properties:
                                             host:
@@ -3278,8 +3274,8 @@ spec:
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: TCPSocket specifies an action
-                                            involving a TCP port.
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -3374,8 +3370,8 @@ spec:
                                         containers.
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
+                                          description: Exec specifies a command to
+                                            execute in the container.
                                           properties:
                                             command:
                                               description: |-
@@ -3396,8 +3392,7 @@ spec:
                                           format: int32
                                           type: integer
                                         grpc:
-                                          description: GRPC specifies an action involving
-                                            a GRPC port.
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
                                           properties:
                                             port:
                                               description: Port number of the gRPC
@@ -3417,7 +3412,7 @@ spec:
                                           - port
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
+                                          description: HTTPGet specifies an HTTP GET
                                             request to perform.
                                           properties:
                                             host:
@@ -3489,8 +3484,8 @@ spec:
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: TCPSocket specifies an action
-                                            involving a TCP port.
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -3822,8 +3817,8 @@ spec:
                                         containers.
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
+                                          description: Exec specifies a command to
+                                            execute in the container.
                                           properties:
                                             command:
                                               description: |-
@@ -3844,8 +3839,7 @@ spec:
                                           format: int32
                                           type: integer
                                         grpc:
-                                          description: GRPC specifies an action involving
-                                            a GRPC port.
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
                                           properties:
                                             port:
                                               description: Port number of the gRPC
@@ -3865,7 +3859,7 @@ spec:
                                           - port
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
+                                          description: HTTPGet specifies an HTTP GET
                                             request to perform.
                                           properties:
                                             host:
@@ -3937,8 +3931,8 @@ spec:
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: TCPSocket specifies an action
-                                            involving a TCP port.
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -4483,8 +4477,8 @@ spec:
                                             More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
-                                              description: Exec specifies the action
-                                                to take.
+                                              description: Exec specifies a command
+                                                to execute in the container.
                                               properties:
                                                 command:
                                                   description: |-
@@ -4499,8 +4493,8 @@ spec:
                                                   x-kubernetes-list-type: atomic
                                               type: object
                                             httpGet:
-                                              description: HTTPGet specifies the http
-                                                request to perform.
+                                              description: HTTPGet specifies an HTTP
+                                                GET request to perform.
                                               properties:
                                                 host:
                                                   description: |-
@@ -4553,9 +4547,8 @@ spec:
                                               - port
                                               type: object
                                             sleep:
-                                              description: Sleep represents the duration
-                                                that the container should sleep before
-                                                being terminated.
+                                              description: Sleep represents a duration
+                                                that the container should sleep.
                                               properties:
                                                 seconds:
                                                   description: Seconds is the number
@@ -4568,8 +4561,8 @@ spec:
                                             tcpSocket:
                                               description: |-
                                                 Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                                for the backward compatibility. There are no validation of this field and
-                                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                                                for backward compatibility. There is no validation of this field and
+                                                lifecycle hooks will fail at runtime when it is specified.
                                               properties:
                                                 host:
                                                   description: 'Optional: Host name
@@ -4602,8 +4595,8 @@ spec:
                                             More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
-                                              description: Exec specifies the action
-                                                to take.
+                                              description: Exec specifies a command
+                                                to execute in the container.
                                               properties:
                                                 command:
                                                   description: |-
@@ -4618,8 +4611,8 @@ spec:
                                                   x-kubernetes-list-type: atomic
                                               type: object
                                             httpGet:
-                                              description: HTTPGet specifies the http
-                                                request to perform.
+                                              description: HTTPGet specifies an HTTP
+                                                GET request to perform.
                                               properties:
                                                 host:
                                                   description: |-
@@ -4672,9 +4665,8 @@ spec:
                                               - port
                                               type: object
                                             sleep:
-                                              description: Sleep represents the duration
-                                                that the container should sleep before
-                                                being terminated.
+                                              description: Sleep represents a duration
+                                                that the container should sleep.
                                               properties:
                                                 seconds:
                                                   description: Seconds is the number
@@ -4687,8 +4679,8 @@ spec:
                                             tcpSocket:
                                               description: |-
                                                 Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                                for the backward compatibility. There are no validation of this field and
-                                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                                                for backward compatibility. There is no validation of this field and
+                                                lifecycle hooks will fail at runtime when it is specified.
                                               properties:
                                                 host:
                                                   description: 'Optional: Host name
@@ -4717,8 +4709,8 @@ spec:
                                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
+                                          description: Exec specifies a command to
+                                            execute in the container.
                                           properties:
                                             command:
                                               description: |-
@@ -4739,8 +4731,7 @@ spec:
                                           format: int32
                                           type: integer
                                         grpc:
-                                          description: GRPC specifies an action involving
-                                            a GRPC port.
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
                                           properties:
                                             port:
                                               description: Port number of the gRPC
@@ -4760,7 +4751,7 @@ spec:
                                           - port
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
+                                          description: HTTPGet specifies an HTTP GET
                                             request to perform.
                                           properties:
                                             host:
@@ -4832,8 +4823,8 @@ spec:
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: TCPSocket specifies an action
-                                            involving a TCP port.
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -4938,8 +4929,8 @@ spec:
                                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
+                                          description: Exec specifies a command to
+                                            execute in the container.
                                           properties:
                                             command:
                                               description: |-
@@ -4960,8 +4951,7 @@ spec:
                                           format: int32
                                           type: integer
                                         grpc:
-                                          description: GRPC specifies an action involving
-                                            a GRPC port.
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
                                           properties:
                                             port:
                                               description: Port number of the gRPC
@@ -4981,7 +4971,7 @@ spec:
                                           - port
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
+                                          description: HTTPGet specifies an HTTP GET
                                             request to perform.
                                           properties:
                                             host:
@@ -5053,8 +5043,8 @@ spec:
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: TCPSocket specifies an action
-                                            involving a TCP port.
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -5405,8 +5395,8 @@ spec:
                                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
+                                          description: Exec specifies a command to
+                                            execute in the container.
                                           properties:
                                             command:
                                               description: |-
@@ -5427,8 +5417,7 @@ spec:
                                           format: int32
                                           type: integer
                                         grpc:
-                                          description: GRPC specifies an action involving
-                                            a GRPC port.
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
                                           properties:
                                             port:
                                               description: Port number of the gRPC
@@ -5448,7 +5437,7 @@ spec:
                                           - port
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
+                                          description: HTTPGet specifies an HTTP GET
                                             request to perform.
                                           properties:
                                             host:
@@ -5520,8 +5509,8 @@ spec:
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: TCPSocket specifies an action
-                                            involving a TCP port.
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -5889,6 +5878,75 @@ spec:
                                 x-kubernetes-list-map-keys:
                                 - name
                                 x-kubernetes-list-type: map
+                              resources:
+                                description: |-
+                                  Resources is the total amount of CPU and Memory resources required by all
+                                  containers in the pod. It supports specifying Requests and Limits for
+                                  "cpu" and "memory" resource names only. ResourceClaims are not supported.
+
+                                  This field enables fine-grained control over resource allocation for the
+                                  entire pod, allowing resource sharing among containers in a pod.
+
+                                  This is an alpha field and requires enabling the PodLevelResources feature
+                                  gate.
+                                properties:
+                                  claims:
+                                    description: |-
+                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                      that are used by this container.
+
+                                      This is an alpha field and requires enabling the
+                                      DynamicResourceAllocation feature gate.
+
+                                      This field is immutable. It can only be set for containers.
+                                    items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: |-
+                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes that resource available
+                                            inside a container.
+                                          type: string
+                                        request:
+                                          description: |-
+                                            Request is the name chosen for a request in the referenced claim.
+                                            If empty, everything from the claim is made available, otherwise
+                                            only the result of this request.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Limits describes the maximum amount of compute resources allowed.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Requests describes the minimum amount of compute resources required.
+                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                type: object
                               restartPolicy:
                                 description: |-
                                   Restart policy for all containers within the pod.
@@ -6013,6 +6071,32 @@ spec:
                                       Note that this field cannot be set when spec.os.name is windows.
                                     format: int64
                                     type: integer
+                                  seLinuxChangePolicy:
+                                    description: |-
+                                      seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                                      It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                                      Valid values are "MountOption" and "Recursive".
+
+                                      "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                                      This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                                      "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                                      This requires all Pods that share the same volume to use the same SELinux label.
+                                      It is not possible to share the same volume among privileged and unprivileged Pods.
+                                      Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                                      whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                                      CSIDriver instance. Other volumes are always re-labelled recursively.
+                                      "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                                      If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                                      If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                                      and "Recursive" for all other volumes.
+
+                                      This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                                      All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: string
                                   seLinuxOptions:
                                     description: |-
                                       The SELinux context to be applied to all containers.
@@ -6421,6 +6505,8 @@ spec:
                                       description: |-
                                         awsElasticBlockStore represents an AWS Disk resource that is attached to a
                                         kubelet's host machine and then exposed to the pod.
+                                        Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                                        awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
                                         More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                       properties:
                                         fsType:
@@ -6452,9 +6538,10 @@ spec:
                                       - volumeID
                                       type: object
                                     azureDisk:
-                                      description: azureDisk represents an Azure Data
-                                        Disk mount on the host and bind mount to the
-                                        pod.
+                                      description: |-
+                                        azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                                        Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                                        are redirected to the disk.csi.azure.com CSI driver.
                                       properties:
                                         cachingMode:
                                           description: 'cachingMode is the Host Caching
@@ -6493,9 +6580,10 @@ spec:
                                       - diskURI
                                       type: object
                                     azureFile:
-                                      description: azureFile represents an Azure File
-                                        Service mount on the host and bind mount to
-                                        the pod.
+                                      description: |-
+                                        azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                                        Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                                        are redirected to the file.csi.azure.com CSI driver.
                                       properties:
                                         readOnly:
                                           description: |-
@@ -6516,8 +6604,9 @@ spec:
                                       - shareName
                                       type: object
                                     cephfs:
-                                      description: cephFS represents a Ceph FS mount
-                                        on the host that shares a pod's lifetime
+                                      description: |-
+                                        cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                                        Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
                                       properties:
                                         monitors:
                                           description: |-
@@ -6570,6 +6659,8 @@ spec:
                                     cinder:
                                       description: |-
                                         cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                        Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                                        are redirected to the cinder.csi.openstack.org CSI driver.
                                         More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                       properties:
                                         fsType:
@@ -6681,7 +6772,7 @@ spec:
                                     csi:
                                       description: csi (Container Storage Interface)
                                         represents ephemeral storage that is handled
-                                        by certain external CSI drivers (Beta feature).
+                                        by certain external CSI drivers.
                                       properties:
                                         driver:
                                           description: |-
@@ -7163,6 +7254,7 @@ spec:
                                       description: |-
                                         flexVolume represents a generic volume resource that is
                                         provisioned/attached using an exec based plugin.
+                                        Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
                                       properties:
                                         driver:
                                           description: driver is the name of the driver
@@ -7208,10 +7300,9 @@ spec:
                                       - driver
                                       type: object
                                     flocker:
-                                      description: flocker represents a Flocker volume
-                                        attached to a kubelet's host machine. This
-                                        depends on the Flocker control service being
-                                        running
+                                      description: |-
+                                        flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                                        Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
                                       properties:
                                         datasetName:
                                           description: |-
@@ -7228,6 +7319,8 @@ spec:
                                       description: |-
                                         gcePersistentDisk represents a GCE Disk resource that is attached to a
                                         kubelet's host machine and then exposed to the pod.
+                                        Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                                        gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
                                         More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                       properties:
                                         fsType:
@@ -7263,7 +7356,7 @@ spec:
                                     gitRepo:
                                       description: |-
                                         gitRepo represents a git repository at a particular revision.
-                                        DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                        Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
                                         EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
                                         into the Pod's container.
                                       properties:
@@ -7287,6 +7380,7 @@ spec:
                                     glusterfs:
                                       description: |-
                                         glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                        Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
                                         More info: https://examples.k8s.io/volumes/glusterfs/README.md
                                       properties:
                                         endpoints:
@@ -7498,9 +7592,9 @@ spec:
                                       - claimName
                                       type: object
                                     photonPersistentDisk:
-                                      description: photonPersistentDisk represents
-                                        a PhotonController persistent disk attached
-                                        and mounted on kubelets host machine
+                                      description: |-
+                                        photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                                        Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
                                       properties:
                                         fsType:
                                           description: |-
@@ -7516,9 +7610,11 @@ spec:
                                       - pdID
                                       type: object
                                     portworxVolume:
-                                      description: portworxVolume represents a portworx
-                                        volume attached and mounted on kubelets host
-                                        machine
+                                      description: |-
+                                        portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                                        Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                                        is on.
                                       properties:
                                         fsType:
                                           description: |-
@@ -7908,8 +8004,9 @@ spec:
                                           x-kubernetes-list-type: atomic
                                       type: object
                                     quobyte:
-                                      description: quobyte represents a Quobyte mount
-                                        on the host that shares a pod's lifetime
+                                      description: |-
+                                        quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                                        Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
                                       properties:
                                         group:
                                           description: |-
@@ -7948,6 +8045,7 @@ spec:
                                     rbd:
                                       description: |-
                                         rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                        Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
                                         More info: https://examples.k8s.io/volumes/rbd/README.md
                                       properties:
                                         fsType:
@@ -8020,9 +8118,9 @@ spec:
                                       - monitors
                                       type: object
                                     scaleIO:
-                                      description: scaleIO represents a ScaleIO persistent
-                                        volume attached and mounted on Kubernetes
-                                        nodes.
+                                      description: |-
+                                        scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                                        Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
                                       properties:
                                         fsType:
                                           default: xfs
@@ -8158,9 +8256,9 @@ spec:
                                           type: string
                                       type: object
                                     storageos:
-                                      description: storageOS represents a StorageOS
-                                        volume attached and mounted on Kubernetes
-                                        nodes.
+                                      description: |-
+                                        storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                                        Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
                                       properties:
                                         fsType:
                                           description: |-
@@ -8205,9 +8303,10 @@ spec:
                                           type: string
                                       type: object
                                     vsphereVolume:
-                                      description: vsphereVolume represents a vSphere
-                                        volume attached and mounted on kubelets host
-                                        machine
+                                      description: |-
+                                        vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                                        Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                                        are redirected to the csi.vsphere.vmware.com CSI driver.
                                       properties:
                                         fsType:
                                           description: |-


### PR DESCRIPTION
## Current situation
If the deployment or configmap is deleted or changed directly it is neither recreated nor updated by the controller. 

## Proposal
Recreate resources if they are deleted.
Increase linting timeout.
